### PR TITLE
fix bug

### DIFF
--- a/lib/service/main-tool-editor-type-mixin.js
+++ b/lib/service/main-tool-editor-type-mixin.js
@@ -38,6 +38,8 @@ export const PropertyMixin = {
             let val = _.get(props, this.field);
             if (val) {
                 this.value = val;
+            }else{
+                this.value = '';
             }
         }
     },


### PR DESCRIPTION
When dragging a new component to the center, the fields same as last component won't be empty and they are filled with last component's fields.